### PR TITLE
feat(installer): シンボリックリンク方式のインストーラーを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,32 @@ Forge は、設計から実装・レビュー・テスト・学習までの開�
 
 ### セットアップ
 
-このリポジトリの内容を `~/.claude/` にコピーして使用します。
+インストーラースクリプトでシンボリックリンクを作成します。`git pull` で更新が自動反映されます。
 
 ```bash
 # リポジトリをクローン
 git clone https://github.com/your-username/forge.git
 cd forge
 
-# ~/.claude/ にコピー（既存の設定がある場合はバックアップを推奨）
+# シンボリックリンク方式でインストール
+bash install.sh
+```
+
+`-y` フラグで確認プロンプトをスキップできます（CI / 非対話環境向け）:
+
+```bash
+bash install.sh -y
+```
+
+> **注意**: 既に `~/.claude/settings.json` が存在する場合は上書きしません。設定を更新する場合は `settings.template.json` をテンプレートとして参照してください。
+
+<details>
+<summary>手動インストール（コピー方式）</summary>
+
+シンボリックリンクを使わずにファイルをコピーする場合:
+
+```bash
+mkdir -p ~/.claude
 cp -r commands/ ~/.claude/commands/
 cp -r agents/ ~/.claude/agents/
 cp -r skills/ ~/.claude/skills/
@@ -49,53 +67,72 @@ cp -r docs/ ~/.claude/docs/
 cp settings.json ~/.claude/settings.json
 ```
 
-または、ワンライナーで一括コピー：
+> コピー方式では `git pull` による更新が反映されません。更新時は再度コピーしてください。
+
+</details>
+
+### インストールの確認
+
+セットアップ後、各ディレクトリ内の要素がシンボリックリンクになっていれば正しくインストールされています:
 
 ```bash
-# ~/.claude/ が存在しない場合は作成
-mkdir -p ~/.claude
-
-# 全ファイルをコピー（README と .git を除く）
-rsync -av --exclude='README.md' --exclude='.git' --exclude='forge-system-prompt.md' ./ ~/.claude/
+ls -la ~/.claude/skills/
 ```
 
-> **注意**: 既に `~/.claude/settings.json` が存在する場合は、手動でマージしてください。上書きすると既存のフック設定が消えます。`settings.template.json` をテンプレートとして参照できます。
+期待される出力（パスはクローン先によって異なります）:
 
-### コピー先の確認
+```
+drwxr-xr-x  .
+drwxr-xr-x  ..
+lrwxr-xr-x  forge-skill-orchestrator -> /path/to/forge/skills/forge-skill-orchestrator
+lrwxr-xr-x  test-driven-development  -> /path/to/forge/skills/test-driven-development
+lrwxr-xr-x  ...
+my-custom-skill/                       # ユーザー独自のスキル（共存可能）
+```
 
-セットアップ後、以下の構造になっていれば正しくインストールされています：
+ディレクトリ構造:
 
 ```
 ~/.claude/
-├── commands/           # スラッシュコマンド（10 個）
-├── agents/
-│   ├── research/       # リサーチエージェント（4 個）
-│   ├── spec/           # スペックエージェント（2 個）
-│   ├── orchestration/  # オーケストレーションエージェント（1 個）
-│   ├── implementation/ # 実装エージェント（3 個）
-│   └── review/         # レビューエージェント（7 個）
-├── skills/             # スキル定義（方法論 7 個 + ドメイン 9 個）
-├── rules/
-│   └── core-essentials.md  # 常時読み込みルール
-├── reference/          # オンデマンド参照ルール（10 個）
-│   ├── common/         # 共通規約
-│   ├── nextjs/         # Next.js 規約
-│   ├── prisma/         # Prisma 規約
-│   └── terraform/      # Terraform 規約
-├── hooks/              # 自動品質ゲート（9 個）
-├── docs/
-│   └── compound/       # 複利ドキュメント
-└── settings.json       # フック・パーミッション設定
+├── commands/                          # ディレクトリはユーザー所有
+│   ├── brainstorm.md -> forge/...     #   中の各ファイルが Forge へのリンク
+│   ├── commit.md -> forge/...
+│   └── my-command.md                  #   ユーザー独自コマンド（共存可能）
+├── agents/                            # エージェント定義
+│   ├── research/ -> forge/...         #   カテゴリ単位でリンク
+│   ├── spec/ -> forge/...
+│   ├── orchestration/ -> forge/...
+│   ├── implementation/ -> forge/...
+│   └── review/ -> forge/...
+├── skills/                            # スキル定義（方法論 + ドメイン）
+│   ├── forge-skill-orchestrator/ -> forge/...
+│   ├── test-driven-development/ -> forge/...
+│   └── my-custom-skill/               #   ユーザー独自スキル（共存可能）
+├── rules/                             # 常時読み込みルール
+│   └── core-essentials.md -> forge/...
+├── reference/                         # オンデマンド参照ルール
+│   ├── common/ -> forge/...
+│   ├── typescript-rules.md -> forge/...
+│   └── ...
+├── hooks/                             # 自動品質ゲート
+│   ├── gate-git-push.js -> forge/...
+│   ├── package.json -> forge/...
+│   └── ...
+├── docs/                              # 複利ドキュメント
+│   ├── compound/ -> forge/...
+│   └── ...
+└── settings.json                      # フック・パーミッション設定（コピー）
 ```
 
 ### アンインストール
 
+アンインストーラースクリプトでシンボリックリンクを削除します:
+
 ```bash
-# Forge のファイルを削除（他の Claude Code 設定は残ります）
-rm -rf ~/.claude/commands ~/.claude/agents ~/.claude/skills \
-       ~/.claude/rules ~/.claude/reference ~/.claude/hooks ~/.claude/docs
-# settings.json は手動で Forge のフック設定を削除してください
+bash uninstall.sh
 ```
+
+Forge が作成したシンボリックリンクのみ削除し、ユーザー独自の資産や Claude Code のランタイムファイル（`projects/`, `teams/`, `tasks/`）には触れません。`settings.json` も自動削除しません。
 
 ---
 
@@ -523,12 +560,14 @@ skills/<skill-name>/
 
 ## リポジトリ構造
 
-本リポジトリの構造です。使用時は `~/.claude/` にコピーしてください。
+本リポジトリの構造です。`bash install.sh` でシンボリックリンク方式でインストールできます。
 
 ```
 forge/
 ├── README.md
 ├── CLAUDE.md                        # ワークフローシステム定義
+├── install.sh                       # シンボリックリンク方式インストーラー
+├── uninstall.sh                     # アンインストーラー
 ├── forge-system-prompt.md           # システムプロンプトテンプレート
 ├── settings.json                    # → ~/.claude/settings.json
 ├── settings.template.json           # 設定テンプレート

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Forge Installer - シンボリックリンク方式（個別要素単位）
+# ~/.claude/ 配下にディレクトリ内の個別要素のシンボリックリンクを作成
+# ユーザー独自の資産と共存可能。git pull で更新が自動反映される
+# ============================================================================
+
+FORGE_DIRS=(commands agents skills rules reference hooks docs)
+CLAUDE_HOME="${HOME}/.claude"
+BACKUP_BASE="${CLAUDE_HOME}/backups"
+FORCE=false
+
+# --- 自己位置特定 ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+FORGE_ROOT="$SCRIPT_DIR"
+
+# --- ヘルパー関数 ---
+info()    { printf "\033[34m[INFO]\033[0m %-40s %s\n" "$1" "$2"; }
+ok()      { printf "\033[32m[ OK ]\033[0m %-40s %s\n" "$1" "$2"; }
+warn()    { printf "\033[33m[WARN]\033[0m %-40s %s\n" "$1" "$2"; }
+error()   { printf "\033[31m[FAIL]\033[0m %-40s %s\n" "$1" "$2"; }
+
+confirm() {
+  $FORCE && return 0
+  read -r -p "$1 [y/N] " response
+  [[ "$response" =~ ^[Yy]$ ]]
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Forge を ~/.claude/ にシンボリックリンク方式でインストールします。
+各ディレクトリ内の個別要素単位でリンクを作成し、ユーザー独自の資産と共存可能です。
+git pull で更新が自動反映されます。
+
+Options:
+  -y, --yes    確認プロンプトをスキップ（非対話モード）
+  -h, --help   このヘルプを表示
+EOF
+  exit 0
+}
+
+# --- 引数パース ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -y|--yes) FORCE=true; shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+# --- Forge リポジトリの検証 ---
+echo ""
+echo "=== Forge Installer ==="
+echo ""
+
+if [[ ! -f "${FORGE_ROOT}/CLAUDE.md" ]]; then
+  error "CLAUDE.md" "Forge リポジトリが見つかりません: ${FORGE_ROOT}"
+  exit 1
+fi
+
+for dir in "${FORGE_DIRS[@]}"; do
+  if [[ ! -d "${FORGE_ROOT}/${dir}" ]]; then
+    error "${dir}/" "ソースディレクトリが見つかりません: ${FORGE_ROOT}/${dir}"
+    exit 1
+  fi
+done
+
+info "Forge root" "${FORGE_ROOT}"
+info "Target" "${CLAUDE_HOME}"
+echo ""
+
+# --- ~/.claude/ の作成 ---
+mkdir -p "${CLAUDE_HOME}"
+
+# --- 旧方式（ディレクトリ丸ごとシンボリックリンク）の検出・移行 ---
+migrated=0
+for dir in "${FORGE_DIRS[@]}"; do
+  dest="${CLAUDE_HOME}/${dir}"
+  if [[ -L "$dest" ]]; then
+    target="$(readlink "$dest")"
+    if [[ "$target" == "${FORGE_ROOT}/"* ]]; then
+      warn "${dir}/" "旧方式のディレクトリシンボリックリンクを検出"
+      rm "$dest"
+      mkdir -p "$dest"
+      ok "${dir}/" "通常ディレクトリに変換（個別リンクに移行します）"
+      migrated=$((migrated + 1))
+    fi
+  fi
+done
+
+if [[ $migrated -gt 0 ]]; then
+  echo ""
+  info "移行" "${migrated} 件の旧方式リンクを個別リンク方式に移行します"
+  echo ""
+fi
+
+# --- 各ディレクトリの個別要素リンク処理 ---
+linked=0
+skipped=0
+backed_up=0
+backup_dir=""
+
+for dir in "${FORGE_DIRS[@]}"; do
+  src_dir="${FORGE_ROOT}/${dir}"
+  dest_dir="${CLAUDE_HOME}/${dir}"
+
+  # ディレクトリが存在しない場合は作成
+  mkdir -p "$dest_dir"
+
+  # ソースディレクトリ内の各要素を処理
+  for item in "${src_dir}"/*; do
+    [[ -e "$item" ]] || continue  # glob が展開されない場合のガード
+
+    item_name="$(basename "$item")"
+    dest="${dest_dir}/${item_name}"
+    display="${dir}/${item_name}"
+
+    # シンボリックリンク済み
+    if [[ -L "$dest" ]]; then
+      current_target="$(readlink "$dest")"
+      if [[ "$current_target" == "$item" ]]; then
+        ok "${display}" "リンク済み（変更なし）"
+        skipped=$((skipped + 1))
+        continue
+      else
+        # リンク先が異なる
+        info "${display}" "リンク先を更新"
+        ln -sfn "$item" "$dest"
+        ok "${display}" "リンク更新完了"
+        linked=$((linked + 1))
+        continue
+      fi
+    fi
+
+    # 通常ファイルまたはディレクトリが存在
+    if [[ -e "$dest" ]]; then
+      warn "${display}" "既存の要素が見つかりました"
+      if confirm "  ${dest} をバックアップしてリンクを作成しますか?"; then
+        if [[ -z "$backup_dir" ]]; then
+          backup_dir="${BACKUP_BASE}/forge-$(date +%Y%m%d-%H%M%S)"
+          mkdir -p "$backup_dir"
+          info "backup" "バックアップ先: ${backup_dir}"
+        fi
+        mkdir -p "${backup_dir}/${dir}"
+        mv "$dest" "${backup_dir}/${dir}/${item_name}"
+        ok "${display}" "バックアップ完了"
+        ln -sfn "$item" "$dest"
+        ok "${display}" "リンク作成完了"
+        linked=$((linked + 1))
+        backed_up=$((backed_up + 1))
+      else
+        warn "${display}" "スキップ（既存の要素を保持）"
+        skipped=$((skipped + 1))
+      fi
+      continue
+    fi
+
+    # 存在しない → 新規リンク
+    ln -sfn "$item" "$dest"
+    ok "${display}" "リンク作成完了"
+    linked=$((linked + 1))
+  done
+done
+
+echo ""
+
+# --- settings.json の処理 ---
+settings_dest="${CLAUDE_HOME}/settings.json"
+if [[ ! -f "$settings_dest" ]]; then
+  cp "${FORGE_ROOT}/settings.json" "$settings_dest"
+  ok "settings.json" "コピー完了"
+else
+  warn "settings.json" "既に存在します（上書きしません）"
+  info "settings.json" "設定を更新する場合は settings.template.json を参照してください"
+fi
+
+echo ""
+
+# --- 検証 ---
+echo "--- 検証 ---"
+errors=0
+for dir in "${FORGE_DIRS[@]}"; do
+  src_dir="${FORGE_ROOT}/${dir}"
+  dest_dir="${CLAUDE_HOME}/${dir}"
+
+  if [[ ! -d "$dest_dir" ]]; then
+    error "${dir}/" "ディレクトリが存在しません"
+    errors=$((errors + 1))
+    continue
+  fi
+
+  for item in "${src_dir}"/*; do
+    [[ -e "$item" ]] || continue
+    item_name="$(basename "$item")"
+    dest="${dest_dir}/${item_name}"
+    display="${dir}/${item_name}"
+
+    if [[ -L "$dest" ]]; then
+      actual_target="$(readlink "$dest")"
+      if [[ "$actual_target" == "$item" ]]; then
+        ok "${display}" "-> ${actual_target}"
+      else
+        error "${display}" "リンク先が不正: ${actual_target}"
+        errors=$((errors + 1))
+      fi
+    else
+      error "${display}" "シンボリックリンクではありません"
+      errors=$((errors + 1))
+    fi
+  done
+done
+
+echo ""
+
+# --- サマリー ---
+echo "=== サマリー ==="
+echo "  リンク作成/更新: ${linked}"
+echo "  スキップ:        ${skipped}"
+echo "  バックアップ:    ${backed_up}"
+if [[ $migrated -gt 0 ]]; then
+  echo "  旧方式から移行:  ${migrated}"
+fi
+if [[ -n "$backup_dir" ]]; then
+  echo "  バックアップ先:  ${backup_dir}"
+fi
+
+if [[ $errors -gt 0 ]]; then
+  echo ""
+  error "検証" "${errors} 件のエラーがあります"
+  exit 1
+fi
+
+echo ""
+ok "完了" "Forge のインストールが完了しました"
+echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Forge Uninstaller
+# install.sh で作成したシンボリックリンクを削除（個別要素単位）
+# FORGE_ROOT 配下を指すリンクのみ削除し、ユーザー独自の資産には触れない
+# ============================================================================
+
+FORGE_DIRS=(commands agents skills rules reference hooks docs)
+CLAUDE_HOME="${HOME}/.claude"
+BACKUP_BASE="${CLAUDE_HOME}/backups"
+FORCE=false
+
+# --- 自己位置特定 ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+FORGE_ROOT="$SCRIPT_DIR"
+
+# --- ヘルパー関数 ---
+ok()      { printf "\033[32m[ OK ]\033[0m %-40s %s\n" "$1" "$2"; }
+warn()    { printf "\033[33m[WARN]\033[0m %-40s %s\n" "$1" "$2"; }
+info()    { printf "\033[34m[INFO]\033[0m %-40s %s\n" "$1" "$2"; }
+
+confirm() {
+  $FORCE && return 0
+  read -r -p "$1 [y/N] " response
+  [[ "$response" =~ ^[Yy]$ ]]
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Forge のシンボリックリンクを ~/.claude/ から削除します。
+ユーザー独自の資産や Claude Code のランタイムファイルには触れません。
+
+Options:
+  -y, --yes    確認プロンプトをスキップ（非対話モード）
+  -h, --help   このヘルプを表示
+EOF
+  exit 0
+}
+
+# --- 引数パース ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -y|--yes) FORCE=true; shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+# --- ~/.claude/ の存在確認 ---
+echo ""
+echo "=== Forge Uninstaller ==="
+echo ""
+
+if [[ ! -d "$CLAUDE_HOME" ]]; then
+  info "~/.claude/" "ディレクトリが存在しません。何もしません。"
+  exit 0
+fi
+
+if ! confirm "Forge のシンボリックリンクを削除しますか?"; then
+  echo "中止しました。"
+  exit 0
+fi
+
+echo ""
+
+# --- 旧方式（ディレクトリ丸ごとシンボリックリンク）の処理 ---
+for dir in "${FORGE_DIRS[@]}"; do
+  dest="${CLAUDE_HOME}/${dir}"
+  if [[ -L "$dest" ]]; then
+    target="$(readlink "$dest")"
+    if [[ "$target" == "${FORGE_ROOT}/"* ]]; then
+      rm "$dest"
+      ok "${dir}/" "旧方式シンボリックリンクを削除 (-> ${target})"
+    else
+      warn "${dir}/" "不明なシンボリックリンク (-> ${target})。スキップ"
+    fi
+  fi
+done
+
+# --- 各ディレクトリ内の個別要素の処理 ---
+removed=0
+skipped=0
+
+for dir in "${FORGE_DIRS[@]}"; do
+  dest_dir="${CLAUDE_HOME}/${dir}"
+  [[ -d "$dest_dir" ]] || continue
+
+  for item in "${dest_dir}"/*; do
+    [[ -e "$item" || -L "$item" ]] || continue
+
+    item_name="$(basename "$item")"
+    display="${dir}/${item_name}"
+
+    if [[ -L "$item" ]]; then
+      target="$(readlink "$item")"
+      # Forge リポジトリ配下を指すリンクのみ削除
+      if [[ "$target" == "${FORGE_ROOT}/"* ]]; then
+        rm "$item"
+        ok "${display}" "削除 (-> ${target})"
+        removed=$((removed + 1))
+      else
+        info "${display}" "Forge 以外のリンク。スキップ"
+        skipped=$((skipped + 1))
+      fi
+    else
+      info "${display}" "ユーザー資産。スキップ"
+      skipped=$((skipped + 1))
+    fi
+  done
+done
+
+echo ""
+
+# --- settings.json ---
+settings_dest="${CLAUDE_HOME}/settings.json"
+if [[ -f "$settings_dest" ]]; then
+  warn "settings.json" "自動削除しません。不要な場合は手動で削除してください"
+fi
+
+# --- バックアップの案内 ---
+if [[ -d "$BACKUP_BASE" ]]; then
+  echo ""
+  info "バックアップ" "以下にバックアップが残っています:"
+  info "" "${BACKUP_BASE}"
+  info "" "復元する場合: cp -r ${BACKUP_BASE}/<backup-name>/<dir>/* ${CLAUDE_HOME}/<dir>/"
+  info "" "削除する場合: rm -rf ${BACKUP_BASE}"
+fi
+
+echo ""
+
+# --- サマリー ---
+echo "=== サマリー ==="
+echo "  削除:    ${removed}"
+echo "  スキップ: ${skipped}"
+echo ""
+ok "完了" "Forge のアンインストールが完了しました"
+echo ""


### PR DESCRIPTION
Closes #8

## Summary

- `install.sh`: `~/.claude/` 配下にサブディレクトリ単位のシンボリックリンクを作成するインストーラー
- `uninstall.sh`: Forge が作成したシンボリックリンクのみを削除するアンインストーラー
- `README.md`: インストール手順をシンボリックリンク方式に更新

## Motivation

従来のコピー方式（`cp` / `rsync`）では `git pull` 後に再コピーが必要だった。シンボリックリンク方式にすることで `git pull` だけで更新が自動反映され、ファイルの重複管理も不要になる。

## Design

### install.sh

- 対象ディレクトリ: `commands/`, `agents/`, `skills/`, `rules/`, `reference/`, `hooks/`, `docs/`
- `~/.claude/` が存在しない場合は自動作成
- 既存ディレクトリの処理:
  - シンボリックリンク済み（同じ先） → スキップ
  - シンボリックリンク済み（別の先） → リンク先を更新
  - 空ディレクトリ → 削除してリンク作成
  - 中身ありのディレクトリ → バックアップ確認後にリンク作成（`~/.claude/backups/` に退避）
- `settings.json` はシンボリックリンクではなくコピー（ユーザー固有の設定とのマージが必要なため）。既存の場合は上書きしない
- インストール完了後に全シンボリックリンクの存在を検証
- `-y` / `--yes` フラグで非対話モード対応

### uninstall.sh

- Forge が作成したシンボリックリンクのみ削除（通常ディレクトリは安全にスキップ）
- `settings.json` は自動削除せず手動対応を案内
- バックアップが残っている場合は復元方法を案内

### README.md

- 推奨インストール方法をシンボリックリンク方式（`install.sh`）に変更
- 従来のコピー方式は折りたたみ（`<details>`）で「手動インストール」として残存
- インストール確認手順をシンボリックリンク前提に更新

## Test plan

- [x] `uninstall.sh -y`: シンボリックリンク7件を全て削除、settings.json は保持
- [x] コピー方式で既存ディレクトリを配置後に `install.sh -y`: 全ディレクトリをバックアップ → シンボリックリンクに置換
- [x] `install.sh` の検証ステップが全てパス（リンク先の有効性確認）
- [x] リンク済み状態で `install.sh` を再実行: 「リンク済み（変更なし）」として全スキップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)